### PR TITLE
Upgrade Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,31 +25,31 @@
     "yeoman-generator"
   ],
   "dependencies": {
-    "chalk": "^1.0.0",
-    "lodash": "^4.6.1",
-    "update-notifier": "^0.6.3",
+    "chalk": "^1.1.3",
+    "lodash": "^4.12.0",
+    "update-notifier": "^0.7.0",
     "xml2js": "^0.4.16",
-    "yeoman-generator": "^0.22.5",
-    "yosay": "^1.0.2"
+    "yeoman-generator": "^0.23.3",
+    "yosay": "^1.1.1"
   },
   "devDependencies": {
-    "commitizen": "^2.7.3",
-    "cz-conventional-changelog": "^1.1.5",
-    "eslint": "^2.1.0",
-    "eslint-config-xo-space": "^0.10.0",
-    "eslint-formatter-pretty": "^0.2.0",
-    "ghooks": "^1.0.3",
-    "gulp": "^3.9.0",
+    "commitizen": "^2.8.1",
+    "cz-conventional-changelog": "^1.1.6",
+    "eslint": "^2.10.2",
+    "eslint-config-xo-space": "^0.13.0",
+    "eslint-formatter-pretty": "^0.2.2",
+    "ghooks": "^1.2.1",
+    "gulp": "^3.9.1",
     "gulp-codecov": "2.0.1",
     "gulp-eslint": "^2.0.0",
     "gulp-exclude-gitignore": "^1.0.0",
-    "gulp-istanbul": "^0.10.3",
+    "gulp-istanbul": "^0.10.4",
     "gulp-line-ending-corrector": "^1.0.1",
-    "gulp-mocha": "^2.0.0",
-    "gulp-nsp": "^2.1.0",
-    "gulp-plumber": "^1.0.0",
+    "gulp-mocha": "^2.2.0",
+    "gulp-nsp": "^2.4.1",
+    "gulp-plumber": "^1.1.0",
     "semantic-release": "^4.3.5",
-    "yeoman-assert": "^2.0.0"
+    "yeoman-assert": "^2.2.1"
   },
   "eslintConfig": {
     "extends": "xo-space",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://edm00se.io/"
   },
   "files": [
-    "generators"
+    "generators",
+    "common"
   ],
   "main": "generators/index.js",
   "engines": {


### PR DESCRIPTION
Fixes #5.

Holding off on semantic-release, since the devDep is in use at 4.3.5 and jumps to 6.2.2 (current); risky upgrade.

[Update]
In actuality, [npm/semantic-release](http://npm.im/semantic-release) cites 4.3.5 as the current version. [David-dm](https://david-dm.org/edm00se/generator-xsp#info=devDependencies&view=table) must be on crack.
[/Update]
