### PR TITLE
feat(generators/app/index.js): provide default inclusion of ExtLib…

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -35,7 +35,14 @@ module.exports = yeoman.Base.extend({
       {
         type: 'checkbox',
         name: 'ddeplugins',
-        message: 'What plugins should be included?',
+        message: function (answerOb) {
+          var str = 'What plugins should be included?';
+          var condition = (answerOb.basetheme === 'Bootstrap3' || answerOb.basetheme === 'Bootstrap3_flat');
+          if (condition) {
+            str += '\n  🍰  ExtLib pre-selected in order to extend ' + answerOb.basetheme;
+          }
+          return str;
+        },
         choices: [
           {
             name: 'ExtLib',
@@ -58,7 +65,18 @@ module.exports = yeoman.Base.extend({
             value: 'org.openntf.junit4xpages.Library'
           }
         ],
-        default: []
+        default: function (answerOb) {
+          var altAr = [];
+          switch (answerOb.basetheme) {
+            case 'Bootstrap3':
+            case 'Bootstrap3_flat':
+              altAr.push('com.ibm.xsp.extlib.library');
+              break;
+            default:
+              break;
+          }
+          return altAr;
+        }
       },
       {
         type: 'confirm',

--- a/test/app.js
+++ b/test/app.js
@@ -36,7 +36,7 @@ describe('generator-xsp:app - app with bower', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withOptions({
         name: testProjName,
-        basetheme: 'webstandard',
+        basetheme: 'Bootstrap3',
         ddeplugins: 'com.ibm.xsp.extlib.library'
       })
       .withPrompts({


### PR DESCRIPTION
…for BS themes

Fixes #22.

Changes proposed in this Pull Request:
- Bootstrap3 themes require ExtLib, now pre-selects from list of plugins

closes #22
