### PR TITLE
fix(dep): bumps dora-cli dep version

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -7,6 +7,6 @@
     },
     "dependencies": {},
     "devDependencies": {
-      "dora-cli": "1.0.1"
+      "dora-cli": "1.0.2"
     }
 }


### PR DESCRIPTION
bumps dora-cli version so as to be usable on Windows

fixes #75