### PR TITLE
Fix/app theme assets when not selected

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -379,7 +379,7 @@ module.exports = class extends Generator {
       this.destinationPath(this.odpPath + '/Resources/Themes/app.theme'),
       {
         basetheme: this.props.basetheme,
-        starterResources: this.props.starterResources || this.starterResources
+        starterResources: (this.props.starterResources === true || this.starterResources)
       }
     );
     this.fs.copyTpl(

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -244,16 +244,9 @@ module.exports = class extends Generator {
             value: 'org.openntf.junit4xpages.Library'
           }
         ],
-        /* istanbul ignore next */
         default: function (answerOb) {
-          const altAr = [];
-          if (
-            answerOb.basetheme === 'Bootstrap3' ||
-            answerOb.baseTheme === 'Bootstrap3_flat'
-          ) {
-            altAr.push('com.ibm.xsp.extlib.library');
-          }
-          return altAr;
+          /* istanbul ignore next */
+          return (answerOb.basetheme === 'Bootstrap3' || answerOb.baseTheme === 'Bootstrap3_flat') ? ['com.ibm.xsp.extlib.library'] : [];
         },
         store: true,
         when: function () {

--- a/generators/app/templates/_app.theme
+++ b/generators/app/templates/_app.theme
@@ -1,6 +1,6 @@
 <theme extends="<%= basetheme %>" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/plugin/com.ibm.designer.domino.stylekits/schema/stylekit.xsd" >
 	<!-- your stuff goes here! -->
-	<% if (starterResources!=false) { %>
+	<% if (starterResources) { %>
 	<resources>
 		<metaData name="viewport" content="width=device-width, initial-scale=1.0" />
 		<styleSheet href="/app.css" />

--- a/test/app.js
+++ b/test/app.js
@@ -20,7 +20,7 @@ describe('generator-xsp:app', function () {
         .toPromise();
     });
 
-    it('creates base ODP files without bower or npm', function () {
+    it('creates base ODP files without bower, npm, or starter resources', function () {
       assert.file([
         'ODP/.project',
         'ODP/AppProperties/database.properties',
@@ -34,6 +34,9 @@ describe('generator-xsp:app', function () {
         'package.json',
         'bower.json'
       ]);
+      assert.noFileContent('ODP/Resources/Themes/app.theme', 'app.css');
+      assert.noFileContent('ODP/Resources/Themes/app.theme', 'app.js');
+      assert.noFileContent('ODP/Resources/Themes/app.theme', 'app.jss');
     });
   });
 
@@ -67,6 +70,9 @@ describe('generator-xsp:app', function () {
         'package.json'
       ]);
       assert.noFile(['bower.json']);
+      assert.fileContent('ODP/Resources/Themes/app.theme', 'app.css');
+      assert.fileContent('ODP/Resources/Themes/app.theme', 'app.js');
+      assert.fileContent('ODP/Resources/Themes/app.theme', 'app.jss');
     });
   });
 


### PR DESCRIPTION
Fixes #85, #86.

Changes proposed in this Pull Request:

- corrects erroneously added references to starter resource files when selected to not include (funnily enough, it didn't add the files, just references in `app.theme`)
- removes reported uncovered lines in the default computing function (and optimizes for brevity)